### PR TITLE
Run only on specific role and adapt to Red Hat osp10

### DIFF
--- a/aci-tripleo-patch/files/apic_gbp_config.yaml.sample
+++ b/aci-tripleo-patch/files/apic_gbp_config.yaml.sample
@@ -1,8 +1,8 @@
 # A Heat environment file which can be used to enable a
 # a Cisco Apic GBP/ML2, configured via puppet
 resource_registry:
-    OS::TripleO::ControllerExtraConfigPre: /opt/aci-tripleo-patch/puppet/cisco-apic.yaml
-    OS::TripleO::ComputeExtraConfigPre: /opt/aci-tripleo-patch/puppet/cisco-apic.yaml
+    OS::TripleO::Tasks::ControllerPreConfig: /opt/aci-tripleo-patch/puppet/cisco-apic.yaml
+    OS::TripleO::Tasks::ComputePreConfig: /opt/aci-tripleo-patch/puppet/cisco-apic.yaml
 
 parameter_defaults:
   ACIApicIp: '10.30.120.140'

--- a/aci-tripleo-patch/files/post_config_aci.yaml.sample
+++ b/aci-tripleo-patch/files/post_config_aci.yaml.sample
@@ -1,4 +1,5 @@
 resource_registry:
-    OS::TripleO::NodeExtraConfigPost: /opt/aci-tripleo-patch/puppet/apic_puppet.yaml
+    OS::TripleO::Tasks::ComputePostConfig: /opt/aci-tripleo-patch/puppet/apic_puppet.yaml
+    OS::TripleO::Tasks::ControllerPostConfig: /opt/aci-tripleo-patch/puppet/apic_puppet.yaml
 parameter_defaults:
   ConfigDebug: True

--- a/aci-tripleo-patch/files/post_config_aci.yaml.sample
+++ b/aci-tripleo-patch/files/post_config_aci.yaml.sample
@@ -3,3 +3,5 @@ resource_registry:
     OS::TripleO::Tasks::ControllerPostConfig: /opt/aci-tripleo-patch/puppet/apic_puppet.yaml
 parameter_defaults:
   ConfigDebug: True
+  DeployIdentifier: abc
+

--- a/aci-tripleo-patch/puppet/apic_puppet.yaml
+++ b/aci-tripleo-patch/puppet/apic_puppet.yaml
@@ -1,10 +1,12 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2015-04-30
 
 description: >
   Configure neutron and opflex
 
 parameters:
   servers:
+    type: json
+  input_values:
     type: json
   ConfigDebug:
     default: false
@@ -40,16 +42,34 @@ resources:
       config:
         get_file: manifests/compute_metadata.pp
 
-  ExtraDeployments:
-    type: OS::Heat::SoftwareDeployments
+  ExtraDeploymentsController:
+    type: OS::Heat::SoftwareDeploymentGroup
     properties:
-      servers:  {get_param: servers}
+      servers:  {get_param: [servers, 'Controller']}
       config: {get_resource: ExtraConfig}
       actions: ['CREATE','UPDATE']
+      input_values: {get_param: input_values}
 
-  ExtraDeployments1:
-    type: OS::Heat::SoftwareDeployments
+  ExtraDeployments1Controller:
+    type: OS::Heat::SoftwareDeploymentGroup
     properties:
-      servers:  {get_param: servers}
+      servers:  {get_param: [servers, 'Controller']}
       config: {get_resource: ExtraConfig1}
       actions: ['CREATE','UPDATE']
+      input_values: {get_param: input_values}
+
+  ExtraDeploymentsCompute:
+    type: OS::Heat::SoftwareDeploymentGroup
+    properties:
+      servers:  {get_param: [servers, 'Compute']}
+      config: {get_resource: ExtraConfig}
+      actions: ['CREATE','UPDATE']
+      input_values: {get_param: input_values}
+
+  ExtraDeployments1Compute:
+    type: OS::Heat::SoftwareDeploymentGroup
+    properties:
+      servers:  {get_param: [servers, 'Compute']}
+      config: {get_resource: ExtraConfig1}
+      actions: ['CREATE','UPDATE']
+      input_values: {get_param: input_values}

--- a/aci-tripleo-patch/puppet/apic_puppet.yaml
+++ b/aci-tripleo-patch/puppet/apic_puppet.yaml
@@ -12,6 +12,8 @@ parameters:
     default: false
     description: Enable puppet debugging
     type: boolean
+  DeployIdentifier:
+    type: string
 
 resources:
   ExtraConfig:
@@ -64,7 +66,8 @@ resources:
       servers:  {get_param: [servers, 'Compute']}
       config: {get_resource: ExtraConfig}
       actions: ['CREATE','UPDATE']
-      input_values: {get_param: input_values}
+      input_values:
+        deploy_identifier: {get_param: DeployIdentifier}
 
   ExtraDeployments1Compute:
     type: OS::Heat::SoftwareDeploymentGroup
@@ -72,4 +75,5 @@ resources:
       servers:  {get_param: [servers, 'Compute']}
       config: {get_resource: ExtraConfig1}
       actions: ['CREATE','UPDATE']
-      input_values: {get_param: input_values}
+      input_values:
+        deploy_identifier: {get_param: DeployIdentifier}

--- a/aci-tripleo-patch/puppet/cisco-apic.yaml
+++ b/aci-tripleo-patch/puppet/cisco-apic.yaml
@@ -3,10 +3,11 @@ heat_template_version: 2015-04-30
 description: Configure hieradata for Cisco Apic configuration
 
 parameters:
-  server:
+  servers:
     description: ID of the controller node to apply this config to
-    type: string
-
+    type: json
+  input_values:
+    type: json
   # Config specific parameters, to be provided via parameter_defaults
   ACIApicIp:
     type: string
@@ -132,10 +133,10 @@ resources:
                 neutron::plugins::apic_gbp::optimized_metadata: {get_input: optimized_neutron_metadata}
                 neutron::plugins::apic_gbp::enable_aim: {get_input: enable_aim}
   CiscoApicOpenstackDeployment:
-    type: OS::Heat::StructuredDeployment
+    type: OS::Heat::StructuredDeployments
     properties:
       config: {get_resource: CiscoApicOpenstackConfig}
-      server: {get_param: server}
+      servers: {get_param: servers}
       input_values:
         opflex_peer_ip: {get_param: ACIOpflexPeerIp}
         opflex_remote_ip: {get_param: ACIOpflexRemoteIp}


### PR DESCRIPTION
The heat template was not working on osp10 cause it was using old resources. Also the puppet code was tried to be run on role as ceph, swift what is not expected and was creating failure at deployment.

Tested and works on newton (Red Hat osp10) and ACI 2.2(2e)

Signed-off-by: Cyril Lopez <cylopez@redhat.com>

fix noironetworks/aci-tripleo-patch#1

Signed-off-by: Cyril Lopez <cylopez@redhat.com>